### PR TITLE
# Use Cases of Infrastructure as Catalog (InCa)  Infrastructure as Ca…

### DIFF
--- a/docs/5_usecases.md
+++ b/docs/5_usecases.md
@@ -1,0 +1,20 @@
+# Use Cases of Infrastructure as Catalog (InCa)
+
+Infrastructure as Catalog (InCa) provides a versatile platform for various use cases aimed at simplifying infrastructure management, promoting collaboration, and enhancing operational efficiency. Here are some of the pivotal use cases of InCa:
+
+## 1. Generation of Infrastructure as Code (IaC)
+With InCa, users can articulate their infrastructure intents in a standardized catalog, which can be utilized to generate IaC. This automation of IaC generation based on user-defined intents streamlines the deployment and management of infrastructure, ensuring consistency and reducing manual errors.
+
+## 2. Change Management
+InCa serves as a robust platform for capturing any change management requirements. By providing a common language to all stakeholders, InCa facilitates clearer communication and collaboration among developers, operations teams, and other personas involved. For instance, a ticket encapsulating all proposed infrastructure changes can be created within the standard catalog, promoting a structured and traceable change management process.
+
+## 3. Knowledge Sharing and Visualization
+The catalog aids in knowledge sharing by offering a simplified visualization of the architecture, which is closely aligned with the actual implementation. As the architecture evolves, the catalog mutates correspondingly, ensuring that stakeholders have an up-to-date understanding of the current infrastructure setup.
+
+## 4. Audit and Validation
+InCa can be leveraged to develop audit tools that validate actual deployments against the defined catalog, identifying any drifts promptly. This feature ensures that the deployed infrastructure adheres to the defined standards and compliances, promoting operational integrity.
+
+## 5. Root Cause Analysis (RCA)
+By integrating signals from change management systems and observability systems with the catalog, InCa facilitates more accurate and insightful Root Cause Analysis (RCA). For example, a tool could capture all pertinent information from these systems and the catalog to backtrack and identify all changes in intent that might have triggered an issue following a change management or release activity.
+
+InCa’s diverse use cases underscore its potential in fostering a more collaborative, efficient, and transparent infrastructure management ecosystem. By converging on a unified language and catalog for infrastructure representation, InCa empowers organizations to navigate the complexities of modern infrastructure landscapes with enhanced clarity and confidence.


### PR DESCRIPTION
This commit introduces a dedicated page outlining the primary use cases of the Infrastructure as Catalog (InCa) initiative. The page enumerates how InCa facilitates the generation of Infrastructure as Code (IaC), streamlines change management processes, promotes knowledge sharing and visualization, aids in auditing and validation, and enhances Root Cause Analysis (RCA). By delineating these use cases, the page aims to provide a comprehensive understanding of the practical benefits and applications of the InCa initiative.



