### PR TITLE
Feature mysql intent

### DIFF
--- a/intent_types/mysql/v1alpha1/README.md
+++ b/intent_types/mysql/v1alpha1/README.md
@@ -17,7 +17,8 @@ This intent type is designed to represent a MySQL database configuration within 
 In the `spec` object:
 - `version`: Specifies the MySQL version (e.g., `5.7`, `8.0`).
 - `server_variables`: An optional field for specifying MySQL server variables as a map of key-value pairs (e.g., `max_connections: "1000"`).
-
+- `replication`: Specifies the master-reader/master-master relation and their replication(s).
+- `backup`: Specifies the backup frequency and retention details in days.
 ## Example
 
 See the `sample.json` file for an example instance of this intent type.

--- a/intent_types/mysql/v1alpha1/sample.json
+++ b/intent_types/mysql/v1alpha1/sample.json
@@ -18,9 +18,9 @@
     },
     "size": {
       "cpu": "100m",
-      "memory": "100Mi",
-      "volume": "50G"
+      "memory": "100Mi"
     },
+    "volume": "50G",
     "replication": {
       "enabled": true,
       "type": "master-slave",
@@ -33,10 +33,13 @@
     "name": "standard"
   },
   "advanced": {
-    "backup":{
-      "enabled":false,
-      "backup_window":"0 0 * * 7"
-    }, 
-    "monitoring": true
+    "common":{
+      "backup":{
+        "enabled":false,
+        "backup_window":"0 0 * * 7",
+        "retention":"30"
+      }, 
+      "monitoring": true
+    }
   }
 }

--- a/intent_types/mysql/v1alpha1/sample.json
+++ b/intent_types/mysql/v1alpha1/sample.json
@@ -16,15 +16,19 @@
       "max_connections": "1000",
       "query_cache_size": "0"
     },
-    "size": {
-      "cpu": "100m",
-      "memory": "100Mi"
-    },
-    "volume": "50G",
     "replication": {
       "enabled": true,
       "type": "master-slave",
       "replica_count": 2
+    },
+    "backup": {
+      "enabled": false,
+      "frequency": "0 0 * * 7",
+      "retention": "30",
+      "storage":{
+        "type":"nfs",
+        "path":"/path/to/backups"
+      }
     }
   },
   "disabled": false,
@@ -32,14 +36,5 @@
     "version": "1.0",
     "name": "standard"
   },
-  "advanced": {
-    "common":{
-      "backup":{
-        "enabled":false,
-        "backup_window":"0 0 * * 7",
-        "retention":"30"
-      }, 
-      "monitoring": true
-    }
-  }
+  "advanced": {}
 }

--- a/intent_types/mysql/v1alpha1/sample.json
+++ b/intent_types/mysql/v1alpha1/sample.json
@@ -23,12 +23,8 @@
     },
     "backup": {
       "enabled": false,
-      "frequency": "0 0 * * 7",
-      "retention": "30",
-      "storage":{
-        "type":"nfs",
-        "path":"/path/to/backups"
-      }
+      "frequency": "7",
+      "retention": "30"
     }
   },
   "disabled": false,

--- a/intent_types/mysql/v1alpha1/sample.json
+++ b/intent_types/mysql/v1alpha1/sample.json
@@ -16,6 +16,11 @@
       "max_connections": "1000",
       "query_cache_size": "0"
     },
+    "size": {
+      "cpu": "100m",
+      "memory": "100Mi",
+      "volume": "50G"
+    },
     "replication": {
       "enabled": true,
       "type": "master-slave",
@@ -27,5 +32,11 @@
     "version": "1.0",
     "name": "standard"
   },
-  "advanced": {}
+  "advanced": {
+    "backup":{
+      "enabled":false,
+      "backup_window":"0 0 * * 7"
+    }, 
+    "monitoring": true
+  }
 }

--- a/intent_types/mysql/v1alpha1/schema.json
+++ b/intent_types/mysql/v1alpha1/schema.json
@@ -40,6 +40,16 @@
             "enabled": {"type": "boolean"},
             "type": {"type": "string"},
             "replica_count": {"type": "integer"}
+          },
+          "backup": {
+            "type": "object",
+            "description": "Optional backup configuration for mysql server.",
+            "properties": {
+              "enabled": {"type": "boolean", "description":"set true to enable backup"}, 
+              "frequency":{"type": "number", "description":"backup frequency"}, 
+              "retention": {"type": "number","description":"Number of days the data will be persistent"}
+           
+            }
           }
         }
       }


### PR DESCRIPTION
### **Contribution Type**
Enhancement in the current intent
 
### Description
This PR introduces a new field in the _'spec'_ object named, _'backup'_ with the view to have additional safety in case the data is damaged, deleted or lost.

### Checklist

- [ ]  Defined Purpose: The intent has a clear and specific purpose, which is to provide a way to backup mysql.
- [ ]  Documentation: Adequate documentation is provided in the README.md file, explaining the purpose and usage of the backup field.
- [ ]  Schema Definition: The schema is clearly defined in the schema.json file for the backup field in the spec object.
- [ ]  Sample Instance: A valid sample _backup_ field is provided in the sample.json file, demonstrating how to use it inside the intent with real-world values.
- [ ]  Implementation Neutrality: The intent is designed to be neutral regarding specific technologies or implementations, focusing on the general requirements for backup.

- [ ] Non-Redundancy: The added field in the intent does not duplicate the functionality of any existing field in the intent, providing common backup configurations.
### Schema Changes Description
This new field, _backup_ in the _spec_ object introduces several configurations specific to the backup details, which can also be utilised in several other database intents.

